### PR TITLE
SPM and warning fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ DerivedData
 *.hmap
 *.ipa
 *.xcuserstate
+.swiftpm
 
 # CocoaPods
 #

--- a/GeohashKit/Geohash.swift
+++ b/GeohashKit/Geohash.swift
@@ -113,7 +113,7 @@ public struct Geohash {
         var lon = (-180.0, 180.0)
         
         for c in hash {
-            guard let bitmap = DecimalToBase32Map.index(of: c) else {
+            guard let bitmap = DecimalToBase32Map.firstIndex(of: c) else {
                 // Break on non geohash code char.
                 return nil
             }

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,33 @@
+// swift-tools-version: 5.7
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+import PackageDescription
+
+let package = Package(
+    name: "GeohashKit",
+    products: [
+        .library(
+            name: "GeohashKit",
+            targets: ["GeohashKit"]
+        ),
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "GeohashKit",
+            dependencies: [],
+            path: "GeohashKit/",
+            sources: [
+                "Geohash.swift",
+                "GeohashBox.swift"
+            ]
+        ),
+        .testTarget(
+            name: "GeohashKitTests",
+            dependencies: ["GeohashKit"],
+            path: "GeohashKitTests/",
+            sources: [
+                "GeohashTests.swift"
+            ]
+        ),
+    ]
+)


### PR DESCRIPTION
- Adds swift package manager support without restructuring anything used for Carthage support or Xcode project definition support
- Fix swift warning to use firstIndex(of:) vs deprecated index(of:)